### PR TITLE
Ctx link master fix compile

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -267,7 +267,8 @@ bool cmd_battery (target *t, int argc, const char **argv)
 {
 	(void)t;
 	(void)argc;
-	(void)argv;	gdb_outf("%s\n", platform_battery_voltage());
+	(void)argv;
+	gdb_outf("%s\n", platform_battery_voltage());
 	return true;
 }
 #endif


### PR DESCRIPTION
compiling ctxLink_master gives errors:

```
CC      command.c
command.c:95:14: error: cast between incompatible function types from '_Bool (*)(void)' to '_Bool (*)(target *, int,  const char **)' {aka '_Bool (*)(struct target_s *, int,  const char **)'} [-Werror=cast-function-type]
   95 | { "battery", (cmd_handler)cmd_battery, "Read the battery voltage" },
      |              ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:98: command.o] Error 1
make: *** [Makefile:25: all] Error 2
```

the fix is to change the structure of cmd_battery to accept the same arguments as all the other functions called by cmd_handler. The arguments are then discarded inside the function.