### PR TITLE
Feature/add support for ambiq apollo 3

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,6 +30,7 @@ option(
 		'cortexm',
 		'riscv32',
 		'riscv64',
+		'apollo3',
 		'at32f4',
 		'ch579',
 		'efm',

--- a/src/target/apollo3.c
+++ b/src/target/apollo3.c
@@ -25,61 +25,61 @@
 static bool apollo_3_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
 static bool apollo_3_flash_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len);
 
-#define FLASH_BASE_ADDRESS 0x00000000U
-#define FLASH_SIZE         0x00100000
-#define FLASH_BLOCK_SIZE   0x2000U
+#define APOLLO_3_FLASH_BASE_ADDRESS 0x00000000U
+#define APOLLO_3_FLASH_SIZE         0x00100000U
+#define APOLLO_3_FLASH_BLOCK_SIZE   0x2000U
 
-#define SRAM_BASE 0x10000000
-#define SRAM_SIZE 0x00060000
+#define APOLLO_3_SRAM_BASE 0x10000000U
+#define APOLLO_3_SRAM_SIZE 0x00060000U
 
-#define CHIPPN_REGISTER 0x40020000U // Address of the Chip Part Number Register
+#define APOLLO_3_CHIPPN_REGISTER 0x40020000U /* Address of the Chip Part Number Register */
 
 /*
 	Define the bitfields of the CHIPPN register.
 	
 	This register contains the part number of the MCU
  */
-#define CHIPPN_PART_NUMBER_MASK         0xff000000U
-#define CHIPPN_PART_NUMBER_BIT_POSITION 0x18U
+#define APOLLO_3_CHIPPN_PART_NUMBER_MASK         0xff000000U
+#define APOLLO_3_CHIPPN_PART_NUMBER_BIT_POSITION 0x18U
 
-#define CHIPPN_FLASH_SIZE_MASK         0x00f00000U
-#define CHIPPN_FLASH_SIZE_BIT_POSITION 0x14U
+#define APOLLO_3_CHIPPN_FLASH_SIZE_MASK         0x00f00000U
+#define APOLLO_3_CHIPPN_FLASH_SIZE_BIT_POSITION 0x14U
 
-#define CHIPPN_SRAM_SIZE_MASK         0x000f0000U
-#define CHIPPN_SRAM_SIZE_BIT_POSITION 0x10U
+#define APOLLO_3_CHIPPN_SRAM_SIZE_MASK         0x000f0000U
+#define APOLLO_3_CHIPPN_SRAM_SIZE_BIT_POSITION 0x10U
 
-#define CHIPPN_REVISION_MASK         0x0000ff00U
-#define CHIPPN_REVISION_BIT_POSITION 0x08U
+#define APOLLO_3_CHIPPN_REVISION_MASK         0x0000ff00U
+#define APOLLO_3_CHIPPN_REVISION_BIT_POSITION 0x08U
 
-#define CHIPPN_PACKAGE_MASK         0x000000c0U
-#define CHIPPN_PACKAGE_BIT_POSITION 0x06U
+#define APOLLO_3_CHIPPN_PACKAGE_MASK         0x000000c0U
+#define APOLLO_3_CHIPPN_PACKAGE_BIT_POSITION 0x06U
 
-#define CHIPPN_PINS_MASK         0x00000038U
-#define CHIPPN_PINS_BIT_POSITION 0x03U
+#define APOLLO_3_CHIPPN_PINS_MASK         0x00000038U
+#define APOLLO_3_CHIPPN_PINS_BIT_POSITION 0x03U
 
-#define CHIPPN_TEMP_MASK         0x00000006U
-#define CHIPPN_TEMP_BIT_POSITION 0x01U
+#define APOLLO_3_CHIPPN_TEMP_MASK         0x00000006U
+#define APOLLO_3_CHIPPN_TEMP_BIT_POSITION 0x01U
 
-#define CHIPPN_QUALIFIED_MASK         0x00000001U
-#define CHIPPN_QUALIFIED_BIT_POSITION 0x0U
+#define APOLLO_3_CHIPPN_QUALIFIED_MASK         0x00000001U
+#define APOLLO_3_CHIPPN_QUALIFIED_BIT_POSITION 0x0U
 
-#define CHIPID0_REGISTER 0x40020004U // Chip ID Register 0
-#define CHIPID1_REGISTER 0x40020008U // Chip ID Register 1
+#define APOLLO_3_CHIPID0_REGISTER 0x40020004U /* Chip ID Register 0 */
+#define APOLLO_3_CHIPID1_REGISTER 0x40020008U /* Chip ID Register 1 */
 
-#define CHIPREV_REGISTER 0x4002000cU // Chip Revision Register
+#define APOLLO_3_CHIPREV_REGISTER 0x4002000cU /* Chip Revision Register */
 
 /*
-	Define the bitfields of the CHIPREV  register.
+	Define the bitfields of the CHIPREV register.
 
 	This register contains the revision of the MCU
 */
-#define CHIPREV_RESERVED 0xfff00000U
-#define CHIPREV_SI_PART  0x000fff00U
-#define CHIPREV_REVMAJ   0x000000f0U
-#define CHIPREV_REVMIN   0x0000000fU
+#define APOLLO_3_CHIPREV_RESERVED 0xfff00000U
+#define APOLLO_3_CHIPREV_SI_PART  0x000fff00U
+#define APOLLO_3_CHIPREV_REVMAJ   0x000000f0U
+#define APOLLO_3_CHIPREV_REVMIN   0x0000000fU
 
-#define VENDOR_ID_ADDRESS 0x40020010 // Vendir ID Register
-#define VENDOR_ID         0x414d4251
+#define APOLLO_3_VENDOR_ID_ADDRESS 0x40020010U /* Vendor ID Register */
+#define APOLLO_3_VENDOR_ID         0x414d4251U
 
 static void apollo_3_add_flash(target_s *target)
 {
@@ -89,9 +89,9 @@ static void apollo_3_add_flash(target_s *target)
 		return;
 	}
 
-	flash->start = FLASH_BASE_ADDRESS;
-	flash->length = FLASH_SIZE;
-	flash->blocksize = FLASH_BLOCK_SIZE;
+	flash->start = APOLLO_3_FLASH_BASE_ADDRESS;
+	flash->length = APOLLO_3_FLASH_SIZE;
+	flash->blocksize = APOLLO_3_FLASH_BLOCK_SIZE;
 	flash->erase = apollo_3_flash_erase;
 	flash->write = apollo_3_flash_write;
 	flash->erased = 0xffU;
@@ -100,27 +100,23 @@ static void apollo_3_add_flash(target_s *target)
 
 bool apollo_3_probe(target_s *target)
 {
-	uint32_t mcu_vendor_id = target_mem_read32(target, VENDOR_ID_ADDRESS);
-	if (mcu_vendor_id != VENDOR_ID) {
+	uint32_t mcu_vendor_id = target_mem32_read32(target, APOLLO_3_VENDOR_ID_ADDRESS);
+	if (mcu_vendor_id != APOLLO_3_VENDOR_ID) {
 		DEBUG_INFO("Invalid vendor ID read\n");
 		return false;
 	} else
 		DEBUG_INFO("Read correct vendor ID\n");
-	/*
-		Read the CHIPPN register to gather MCU details
-	 */
-	uint32_t mcu_chip_partnum = target_mem_read32(target, CHIPPN_REGISTER);
-	/*
-		Check the chip is an Apollo 3
-	 */
-	if ((mcu_chip_partnum & CHIPPN_PART_NUMBER_MASK) != 0x06000000) {
+	/* Read the CHIPPN register to gather MCU details */
+	uint32_t mcu_chip_partnum = target_mem32_read32(target, APOLLO_3_CHIPPN_REGISTER);
+	/* Check the chip is an Apollo 3 */
+	if ((mcu_chip_partnum & APOLLO_3_CHIPPN_PART_NUMBER_MASK) != 0x06000000) {
 		DEBUG_INFO("Invalid chip type read\n");
 		return false;
 	}
 
-	target->driver = "apollo 3 Blue";
+	target->driver = "Apollo 3 Blue";
 
-	target_add_ram(target, SRAM_BASE, SRAM_SIZE);
+	target_add_ram32(target, APOLLO_3_SRAM_BASE, APOLLO_3_SRAM_SIZE);
 
 	apollo_3_add_flash(target);
 	return true;

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -74,6 +74,7 @@ if is_firmware_build
 		'riscv32': 'RISC-V 32-bit support',
 		'riscv64': 'RISC-V 64-bit support',
 		'at32f4': 'Arterytek parts',
+		'apollo3': 'Ambiq Apollo3 parts',
 		'ch579': 'CH579',
 		'efm': 'Energy Micro parts',
 		'hc32': 'HC32 parts',
@@ -155,6 +156,11 @@ target_riscv32 = declare_dependency(
 target_riscv64 = declare_dependency(
 	sources: files('riscv64.c'),
 	dependencies: target_riscv,
+)
+
+target_apollo3 = declare_dependency(
+	sources: files('apollo3.c'),
+	dependencies: target_cortexm,
 )
 
 target_ch579 = declare_dependency(
@@ -320,6 +326,7 @@ libbmd_target_deps = [
 	target_riscv32,
 	target_riscv64,
 	# Enable all targets for libbmd
+	target_apollo3,
 	target_at32f4,
 	target_ch579,
 	target_efm,

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -52,7 +52,7 @@ bool nrf51_mdm_probe(adiv5_access_port_s *ap);
 bool rp_rescue_probe(adiv5_access_port_s *ap);
 
 bool at32f40x_probe(target_s *target); // STM32 clones from Artery
-bool apollo_3_probe(target_s *t);
+bool apollo_3_probe(target_s *target);
 bool at32f43x_probe(target_s *target);
 bool ch32f1_probe(target_s *target); // will catch all the clones
 bool ch579_probe(target_s *target);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

* Brought your Ambiq Apollo3 support up to date
* Added meson file support for this target
* made the changes requested by @dragonmux 
* Double-checked that the probe and flash mapping still works on my Sparkfun expLoRaBLE board (has NM180100 SoC which uses the Apollo3)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
